### PR TITLE
Add dynamic field configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Custom Fields
+
+The app allows you to define custom item fields that are saved in Firestore.
+
+1. Open **Field Settings** from the home screen.
+2. Enter a field name and an optional validation regex, then tap **Add Field**.
+3. Open **Add Item** to see a form generated from your saved field definitions.
+4. Submitted item data is stored in the `items` collection using the dynamic
+   keys you configured.

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,6 @@
+// Placeholder Firebase options. Replace with values from Firebase project.
+// Generated via `flutterfire configure`.
+
+class DefaultFirebaseOptions {
+  static const currentPlatform = null;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,125 +1,57 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
+import 'pages/item_form_page.dart';
+import 'pages/settings_page.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      title: 'Inventory Pro',
+      theme: ThemeData(useMaterial3: true),
+      home: const HomePage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
+      appBar: AppBar(title: const Text('Inventory Pro')),
       body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
         child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
           mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
+          children: [
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const ItemFormPage()),
+              ),
+              child: const Text('Add Item'),
             ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SettingsPage()),
+              ),
+              child: const Text('Field Settings'),
             ),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/models/field_definition.dart
+++ b/lib/models/field_definition.dart
@@ -1,0 +1,22 @@
+class FieldDefinition {
+  final String id;
+  final String name;
+  final String? pattern;
+
+  FieldDefinition({required this.id, required this.name, this.pattern});
+
+  factory FieldDefinition.fromMap(String id, Map<String, dynamic> data) {
+    return FieldDefinition(
+      id: id,
+      name: data['name'] as String,
+      pattern: data['pattern'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      if (pattern != null) 'pattern': pattern,
+    };
+  }
+}

--- a/lib/pages/item_form_page.dart
+++ b/lib/pages/item_form_page.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import '../services/inventory_service.dart';
+import '../models/field_definition.dart';
+
+class ItemFormPage extends StatefulWidget {
+  const ItemFormPage({super.key});
+
+  @override
+  State<ItemFormPage> createState() => _ItemFormPageState();
+}
+
+class _ItemFormPageState extends State<ItemFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _controllers = <String, TextEditingController>{};
+  final InventoryService _service = InventoryService();
+
+  @override
+  void dispose() {
+    for (final controller in _controllers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Item')),
+      body: StreamBuilder<List<FieldDefinition>>(
+        stream: _service.fieldDefinitionsStream(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final fields = snapshot.data!;
+          for (final field in fields) {
+            _controllers.putIfAbsent(field.id, () => TextEditingController());
+          }
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: ListView(
+                children: [
+                  ...fields.map((field) {
+                    final controller = _controllers[field.id]!;
+                    return TextFormField(
+                      controller: controller,
+                      decoration: InputDecoration(labelText: field.name),
+                      validator: (value) {
+                        if (field.pattern != null && value != null) {
+                          final reg = RegExp(field.pattern!);
+                          if (!reg.hasMatch(value)) {
+                            return 'Invalid ${field.name}';
+                          }
+                        }
+                        if (value == null || value.isEmpty) {
+                          return 'Required';
+                        }
+                        return null;
+                      },
+                    );
+                  }),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      if (_formKey.currentState!.validate()) {
+                        final data = {
+                          for (final field in fields)
+                            field.name: _controllers[field.id]!.text,
+                        };
+                        _service.saveItem(data).then((_) => Navigator.pop(context));
+                      }
+                    },
+                    child: const Text('Save'),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import '../services/inventory_service.dart';
+import '../models/field_definition.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  final _nameController = TextEditingController();
+  final _patternController = TextEditingController();
+  final InventoryService _service = InventoryService();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _patternController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Field Settings')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Field Name'),
+            ),
+            TextField(
+              controller: _patternController,
+              decoration: const InputDecoration(
+                labelText: 'Validation Regex (optional)',
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                final name = _nameController.text.trim();
+                final pattern = _patternController.text.trim();
+                if (name.isEmpty) return;
+                _service
+                    .addFieldDefinition(
+                      FieldDefinition(
+                        id: '',
+                        name: name,
+                        pattern: pattern.isEmpty ? null : pattern,
+                      ),
+                    )
+                    .then((_) {
+                      _nameController.clear();
+                      _patternController.clear();
+                    });
+              },
+              child: const Text('Add Field'),
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: StreamBuilder<List<FieldDefinition>>(
+                stream: _service.fieldDefinitionsStream(),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  final fields = snapshot.data!;
+                  return ListView(
+                    children: fields
+                        .map((f) => ListTile(title: Text(f.name)))
+                        .toList(),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/inventory_service.dart
+++ b/lib/services/inventory_service.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/field_definition.dart';
+
+class InventoryService {
+  final FirebaseFirestore _firestore;
+  InventoryService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> get _fieldsCollection =>
+      _firestore.collection('field_definitions');
+
+  CollectionReference<Map<String, dynamic>> get _itemsCollection =>
+      _firestore.collection('items');
+
+  Stream<List<FieldDefinition>> fieldDefinitionsStream() {
+    return _fieldsCollection.snapshots().map((snapshot) {
+      return snapshot.docs
+          .map((doc) => FieldDefinition.fromMap(doc.id, doc.data()))
+          .toList();
+    });
+  }
+
+  Future<void> addFieldDefinition(FieldDefinition field) {
+    return _fieldsCollection.add(field.toMap());
+  }
+
+  Future<void> saveItem(Map<String, dynamic> data) {
+    return _itemsCollection.add(data);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  firebase_core: ^2.27.0
+  cloud_firestore: ^4.15.0
+
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- integrate Firebase dependencies
- allow defining custom fields in a settings page
- dynamically build item form from stored field definitions
- save items and field definitions to Firestore
- document field customization workflow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d4540e0c832e9f276c3b6477b89f